### PR TITLE
adding new parameter, alert_per_host to alert a cluster, instead of a host

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -11,6 +11,7 @@ module "rpc" {
   warning_recipients = ["slack-bei"]
   renotify_interval  = 0
   notify_audit       = false
+  alert_per_host     = true
 
   server_latency_p95_thresholds = {
     critical = 1000

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   monitor_enabled = "${var.enabled && length(var.recipients) > 0 ? 1 : 0}"
-  with_host = "host,classname,methodname"
-  without_host = "classname,methodname"
+  with_host = "{host,classname,methodname}"
+  without_host = "{classname,methodname}"
   alert_by = "${var.alert_per_host ? local.with_host : local.without_host}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -188,7 +188,7 @@ module "monitor_server_exception" {
   timeboard_id   = "${join(",", datadog_timeboard.rpc.*.id)}"
 
   name               = "${var.product_domain} - ${var.cluster} - ${var.environment} - RPC Server Exception is High on Class: {{ classname }} Method: {{ methodname }}"
-  query              = "${coalesce(var.server_exception_custom_query, "avg(last_1m):avg:rpc.server.exc.count{cluster:${var.cluster}, environment:${var.environment}} by {host,classname,methodname} >= ${var.server_exception_thresholds["critical"]}")}"
+  query              = "${coalesce(var.server_exception_custom_query, "avg(last_1m):avg:rpc.server.exc.count{cluster:${var.cluster}, environment:${var.environment}} by ${local.alert_by} >= ${var.server_exception_thresholds["critical"]}")}"
   thresholds         = "${var.server_exception_thresholds}"
   message            = "${var.server_exception_message}"
   escalation_message = "${var.server_exception_escalation_message}"
@@ -212,7 +212,7 @@ module "monitor_client_latency_p95" {
   timeboard_id   = "${join(",", datadog_timeboard.rpc.*.id)}"
 
   name               = "${var.product_domain} - ${var.cluster} - ${var.environment} - RPC Client Latency is High on Method: {{ methodname }} Destination: {{ destnodeid }}"
-  query              = "${coalesce(var.client_latency_p95_custom_query, "avg(last_1m):avg:rpc.client.ltcy.p95{cluster:${var.cluster}, environment:${var.environment}} by {host,methodname,destnodeid} >= ${var.client_latency_p95_thresholds["critical"]}")}"
+  query              = "${coalesce(var.client_latency_p95_custom_query, "avg(last_1m):avg:rpc.client.ltcy.p95{cluster:${var.cluster}, environment:${var.environment}} by ${local.alert_by} >= ${var.client_latency_p95_thresholds["critical"]}")}"
   thresholds         = "${var.client_latency_p95_thresholds}"
   message            = "${var.client_latency_p95_message}"
   escalation_message = "${var.client_latency_p95_escalation_message}"
@@ -236,7 +236,7 @@ module "monitor_client_exception" {
   timeboard_id   = "${join(",", datadog_timeboard.rpc.*.id)}"
 
   name               = "${var.product_domain} - ${var.cluster} - ${var.environment} - RPC Client Exception is High on Method: {{ methodname }} Destination: {{ destnodeid }}"
-  query              = "${coalesce(var.client_exception_custom_query, "avg(last_1m):avg:rpc.client.exc.count{cluster:${var.cluster}, environment:${var.environment}} by {host,methodname,destnodeid} >= ${var.client_exception_thresholds["critical"]}")}"
+  query              = "${coalesce(var.client_exception_custom_query, "avg(last_1m):avg:rpc.client.exc.count{cluster:${var.cluster}, environment:${var.environment}} by ${local.alert_by} >= ${var.client_exception_thresholds["critical"]}")}"
   thresholds         = "${var.client_exception_thresholds}"
   message            = "${var.client_exception_message}"
   escalation_message = "${var.client_exception_escalation_message}"
@@ -260,7 +260,7 @@ module "monitor_circuit_breaker_status" {
   timeboard_id   = "${join(",", datadog_timeboard.rpc.*.id)}"
 
   name               = "${var.product_domain} - ${var.cluster} - ${var.environment} - Circuit Breaker is Open on Class: {{ classname }} Method: {{ methodname }}"
-  query              = "${coalesce(var.circuit_breaker_status_custom_query, "avg(last_1m):avg:CircuitBreaker.status.lastNumber{cluster:${var.cluster}, environment:${var.environment}} by {host,classname,methodname} >= ${var.circuit_breaker_status_thresholds["critical"]}")}" 
+  query              = "${coalesce(var.circuit_breaker_status_custom_query, "avg(last_1m):avg:CircuitBreaker.status.lastNumber{cluster:${var.cluster}, environment:${var.environment}} by ${local.alert_by} >= ${var.circuit_breaker_status_thresholds["critical"]}")}" 
   thresholds         = "${var.circuit_breaker_status_thresholds}"
   message            = "${var.circuit_breaker_status_message}"
   escalation_message = "${var.circuit_breaker_status_escalation_message}"

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "enabled" {
   description = "To enable this module"
 }
 
+variable "alert_per_host" {
+  type        = "string"
+  default     = true
+  description = "To enable alert per host instead of per cluster"
+}
+
 variable "product_domain" {
   type        = "string"
   description = "The name of the product domain"


### PR DESCRIPTION
background:
as many products move to ASG, there is some needs in a team to alert based on cluster instead of host.

implementation:
adding new variable to determine is the alert need to be by host or not